### PR TITLE
Initial patch to update the caffe build system to support the Qualcommm Snapdragon Math Libraries (QSML).

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,27 @@ export ANDROID_ABI="arm64-v8a" # Optional, see the note below
 ./build.sh <path/to/ndk>
 ```
 
+### Qualcomm Snapdragon Math Libraries (QSML)
+QSML is a high performance implementation of BLAS and LAPACK for Snapdragon.  QSML can be
+downloaded from the Qualcomm Developer Network [here](https://developer.qualcomm.com/software/snapdragon-math-libraries).
+Once QSML is installed, it can be enabled by setting:
+
+```
+export USE_QSML=1
+```
+
+By default, we assume QSML version 0.15.2, this can be changed by changing the appropriate environment variable below.  We also assume the default installation directory.  For instance:
+
+```
+export QSML_VERSION=0.15.2
+
+export QSML\_ROOT\_DIR=/opt/Qualcomm/QSML-$QSML_VERSION/
+```
+
+If you run into any problems or have any questions, feel free to contact us at our [forums](https://developer.qualcomm.com/forums/software/snapdragon-math-libraries) or via [email](qsml@qti.qualcomm.com).
+
 ### NOTE: OpenBLAS
-OpenBLAS is the only supported BLAS choice now, and the supported ABIs are the following:
+OpenBLAS is one of the supported BLAS choices, and the supported ABIs are the following:
 
 * `armeabi`
 * `armeabi-v7a-hard-softfp with NEON`

--- a/build.sh
+++ b/build.sh
@@ -17,9 +17,27 @@ cd "${WD}"
 export ANDROID_ABI="${ANDROID_ABI:-"arm64-v8a"}"
 export N_JOBS=${N_JOBS:-1}
 
-if ! ./scripts/build_openblas.sh ; then
-    echo "Failed to build OpenBLAS"
-    exit 1
+if [ ${USE_QSML} ]; then
+
+    export QSML_VERSION=${QSML_VERSION:-"0.15.2"}
+
+    export QSML_ROOT_DIR=${QSML_ROOT_DIR:-"/opt/Qualcomm/QSML-${QSML_VERSION}/android"}
+
+    if [ "$ANDROID_ABI" = "armeabi-v7a with NEON" ]; then
+      export QSML_DIR="${QSML_ROOT_DIR}/arm32/lp64/ndk-r11/"
+    elif [ "$ANDROID_ABI" = "arm64-v8a" ]; then
+      export QSML_DIR="${QSML_ROOT_DIR}/arm64/lp64/ndk-r11/"
+    else
+      echo "**** ERROR **** ANDROID_ABI incorrectly set, only \"armeabi-v7a with NEON\" or \"arm64-v8a\" are supported with QSML"
+    fi
+
+    echo "Using QSML from $QSML_DIR"
+
+else
+    if ! ./scripts/build_openblas.sh ; then
+      echo "Failed to build OpenBLAS"
+      exit 1
+    fi
 fi
 
 ./scripts/build_boost.sh

--- a/scripts/build_caffe.sh
+++ b/scripts/build_caffe.sh
@@ -25,6 +25,13 @@ PROTOBUF_ROOT=${ANDROID_LIB_ROOT}/protobuf
 export LMDB_DIR=${ANDROID_LIB_ROOT}/lmdb
 export OpenBLAS_HOME="${ANDROID_LIB_ROOT}/openblas"
 
+USE_QSML=${USE_QSML:-0}
+if [ ${USE_QSML} -eq 1 ]; then
+    BLAS=QSML
+else
+    BLAS=open
+fi
+
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
@@ -42,7 +49,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="${WD}/android-cmake/android.toolchain.cmake" \
       -DUSE_LMDB=ON \
       -DUSE_LEVELDB=OFF \
       -DUSE_HDF5=OFF \
-      -DBLAS=open \
+      -DBLAS=${BLAS} \
+      -DQSML_VERSION="${QSML_VERSION}" \
+      -DQSML_DIR="${QSML_DIR}"
       -DBOOST_ROOT="${BOOST_HOME}" \
       -DGFLAGS_INCLUDE_DIR="${GFLAGS_HOME}/include" \
       -DGFLAGS_LIBRARY="${GFLAGS_HOME}/lib/libgflags.a" \


### PR DESCRIPTION
QSML is a high performance implementation of BLAS and LAPACK for Snapdragon.  QSML can be downloaded from the Qualcomm Developer Network [here](https://developer.qualcomm.com/software/snapdragon-math-libraries).

This is the first patch to enable QSML support for Caffe.